### PR TITLE
fix: Add complete internationalization for Impressum page

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -111,7 +111,52 @@
     "impressum": {
     "title": "Legal Information",
     "metaDescription": "Legal information and company details for RAMPA",
-    "content": "Legal information and terms of service for RAMPA will be provided here."
+    "sections": {
+      "companyInfo": {
+        "title": "Company Information",
+        "name": "RAMPA Cash GmbH",
+        "address": "Musterstraße 123",
+        "city": "12345 Berlin",
+        "country": "Germany"
+      },
+      "contact": {
+        "title": "Contact Information",
+        "phone": "Phone:",
+        "email": "Email:",
+        "website": "Website:"
+      },
+      "editoriallyResponsible": {
+        "title": "Editorially Responsible",
+        "name": "RAMPA Cash GmbH",
+        "address": "Musterstraße 123",
+        "city": "12345 Berlin"
+      },
+      "euDispute": {
+        "title": "EU Dispute Resolution",
+        "text": "The European Commission provides a platform for online dispute resolution (ODR):",
+        "link": "https://ec.europa.eu/consumers/odr/",
+        "emailNote": "Our email address can be found above in the impressum."
+      },
+      "consumerDispute": {
+        "title": "Consumer Dispute Resolution",
+        "text": "We are not willing or obliged to participate in dispute resolution proceedings before a consumer arbitration board."
+      },
+      "contentLiability": {
+        "title": "Liability for Content",
+        "paragraph1": "As service providers, we are liable for our own content of these websites according to Sec. 7, Para. 1 German Telemedia Act (TMG). However, pursuant to Secs. 8 to 10 German Telemedia Act (TMG), we as service providers are under no obligation to monitor submitted or stored information or to investigate circumstances pointing to illegal activity.",
+        "paragraph2": "Legal obligations to removing information or to blocking the use of information remain unchallenged. In this case, liability is only possible at the time of knowledge about a specific violation of law. Illegal content will be removed immediately at the time we get knowledge of it."
+      },
+      "linkLiability": {
+        "title": "Liability for Links",
+        "paragraph1": "Our offer includes links to external third party websites. We have no influence on the contents of those websites, therefore we cannot guarantee for those contents. Providers or administrators of linked websites are always responsible for the contents of the linked websites.",
+        "paragraph2": "All linked websites have been checked for possible violations of law at the time of the establishment of the link. Illegal contents were not detected at the time of the linking. A permanent monitoring of the contents of linked websites cannot be imposed without reasonable indications that there has been a violation of law. Illegal links will be removed immediately at the time we get knowledge of it."
+      },
+      "copyright": {
+        "title": "Copyright",
+        "paragraph1": "Contents and compilations published on these websites by the providers are subject to German copyright laws. Reproduction, editing, distribution as well as the use of any kind outside the scope of the copyright law require a written permission of the author or originator.",
+        "paragraph2": "Downloads and copies of these websites are permitted for private use only. The commercial use of our contents without permission of the originator is prohibited."
+      }
+    }
   },
   "cookies": {
     "title": "We use cookies to enhance your experience",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -111,7 +111,52 @@
   "impressum": {
     "title": "Información Legal",
     "metaDescription": "Información legal y detalles de la empresa para RAMPA",
-    "content": "Información legal y términos de servicio para RAMPA se proporcionarán aquí."
+    "sections": {
+      "companyInfo": {
+        "title": "Información de la Empresa",
+        "name": "RAMPA Cash GmbH",
+        "address": "Musterstraße 123",
+        "city": "12345 Berlín",
+        "country": "Alemania"
+      },
+      "contact": {
+        "title": "Información de Contacto",
+        "phone": "Teléfono:",
+        "email": "Email:",
+        "website": "Sitio web:"
+      },
+      "editoriallyResponsible": {
+        "title": "Responsable Editorial",
+        "name": "RAMPA Cash GmbH",
+        "address": "Musterstraße 123",
+        "city": "12345 Berlín"
+      },
+      "euDispute": {
+        "title": "Resolución de Disputas de la UE",
+        "text": "La Comisión Europea proporciona una plataforma para la resolución de disputas en línea (ODR):",
+        "link": "https://ec.europa.eu/consumers/odr/",
+        "emailNote": "Nuestra dirección de correo electrónico se puede encontrar arriba en el aviso legal."
+      },
+      "consumerDispute": {
+        "title": "Resolución de Disputas del Consumidor",
+        "text": "No estamos dispuestos ni obligados a participar en procedimientos de resolución de disputas ante una junta de arbitraje de consumidores."
+      },
+      "contentLiability": {
+        "title": "Responsabilidad por el Contenido",
+        "paragraph1": "Como proveedores de servicios, somos responsables de nuestro propio contenido de estos sitios web según la Sec. 7, Para. 1 de la Ley Alemana de Telemedia (TMG). Sin embargo, de conformidad con las Secs. 8 a 10 de la Ley Alemana de Telemedia (TMG), nosotros como proveedores de servicios no tenemos la obligación de monitorear la información enviada o almacenada o investigar circunstancias que apunten a actividad ilegal.",
+        "paragraph2": "Las obligaciones legales de eliminar información o bloquear el uso de información permanecen sin cambios. En este caso, la responsabilidad solo es posible en el momento del conocimiento sobre una violación específica de la ley. El contenido ilegal será eliminado inmediatamente en el momento en que tengamos conocimiento de ello."
+      },
+      "linkLiability": {
+        "title": "Responsabilidad por Enlaces",
+        "paragraph1": "Nuestra oferta incluye enlaces a sitios web externos de terceros. No tenemos influencia sobre el contenido de esos sitios web, por lo tanto no podemos garantizar ese contenido. Los proveedores o administradores de sitios web enlazados siempre son responsables del contenido de los sitios web enlazados.",
+        "paragraph2": "Todos los sitios web enlazados han sido verificados en busca de posibles violaciones de la ley en el momento del establecimiento del enlace. No se detectaron contenidos ilegales en el momento del enlace. Un monitoreo permanente del contenido de sitios web enlazados no puede imponerse sin indicaciones razonables de que ha habido una violación de la ley. Los enlaces ilegales serán eliminados inmediatamente en el momento en que tengamos conocimiento de ello."
+      },
+      "copyright": {
+        "title": "Derechos de Autor",
+        "paragraph1": "Los contenidos y compilaciones publicados en estos sitios web por los proveedores están sujetos a las leyes alemanas de derechos de autor. La reproducción, edición, distribución así como el uso de cualquier tipo fuera del alcance de la ley de derechos de autor requiere un permiso por escrito del autor u originador.",
+        "paragraph2": "Las descargas y copias de estos sitios web están permitidas solo para uso privado. El uso comercial de nuestros contenidos sin permiso del originador está prohibido."
+      }
+    }
   },
   "cookies": {
     "title": "Usamos cookies para mejorar tu experiencia",


### PR DESCRIPTION
- Add detailed legal information translations for English and Spanish
- Include company info, contact details, EU dispute resolution, and legal disclaimers
- Fix missing translation keys that were showing as raw keys on the page
- Ensure proper localization for both languages