### PR TITLE
fix: Add complete internationalization for Impressum page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1858,7 +1858,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.30",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.32.tgz",
+      "integrity": "sha512-n9mQdigI6iZ/DF6pCTwMKeWgF2e8lg7qgt5M7HXMLtyhZYMnf/u905M18sSpPmHL9MKp9JHo56C6jrD2EvWxng==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1870,12 +1872,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.30.tgz",
-      "integrity": "sha512-EAqfOTb3bTGh9+ewpO/jC59uACadRHM6TSA9DdxJB/6gxOpyV+zrbqeXiFTDy9uV6bmipFDkfpAskeaDcO+7/g==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.32.tgz",
+      "integrity": "sha512-osHXveM70zC+ilfuFa/2W6a1XQxJTvEhzEycnjUaVE8kpUS09lDpiDDX2YLdyFCzoUbvbo5r0X1Kp4MllIOShw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1885,12 +1888,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.30.tgz",
-      "integrity": "sha512-TyO7Wz1IKE2kGv8dwQ0bmPL3s44EKVencOqwIY69myoS3rdpO1NPg5xPM5ymKu7nfX4oYJrpMxv8G9iqLsnL4A==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.32.tgz",
+      "integrity": "sha512-P9NpCAJuOiaHHpqtrCNncjqtSBi1f6QUdHK/+dNabBIXB2RUFWL19TY1Hkhu74OvyNQEYEzzMJCMQk5agjw1Qg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1900,12 +1904,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.30.tgz",
-      "integrity": "sha512-I5lg1fgPJ7I5dk6mr3qCH1hJYKJu1FsfKSiTKoYwcuUf53HWTrEkwmMI0t5ojFKeA6Vu+SfT2zVy5NS0QLXV4Q==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.32.tgz",
+      "integrity": "sha512-v7JaO0oXXt6d+cFjrrKqYnR2ubrD+JYP7nQVRZgeo5uNE5hkCpWnHmXm9vy3g6foMO8SPwL0P3MPw1c+BjbAzA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1915,7 +1920,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.30",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.32.tgz",
+      "integrity": "sha512-tA6sIKShXtSJBTH88i0DRd6I9n3ZTirmwpwAqH5zdJoQF7/wlJXR8DkPmKwYl5mFWhEKr5IIa3LfpMW9RRwKmQ==",
       "cpu": [
         "arm64"
       ],
@@ -1929,12 +1936,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.30.tgz",
-      "integrity": "sha512-8Ly7okjssLuBoe8qaRCcjGtcMsv79hwzn/63wNeIkzJVFVX06h5S737XNr7DZwlsbTBDOyI6qbL2BJB5n6TV/w==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.32.tgz",
+      "integrity": "sha512-7S1GY4TdnlGVIdeXXKQdDkfDysoIVFMD0lJuVVMeb3eoVjrknQ0JNN7wFlhCvea0hEk0Sd4D1hedVChDKfV2jw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1944,12 +1952,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.30.tgz",
-      "integrity": "sha512-dBmV1lLNeX4mR7uI7KNVHsGQU+OgTG5RGFPi3tBJpsKPvOPtg9poyav/BYWrB3GPQL4dW5YGGgalwZ79WukbKQ==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.32.tgz",
+      "integrity": "sha512-OHHC81P4tirVa6Awk6eCQ6RBfWl8HpFsZtfEkMpJ5GjPsJ3nhPe6wKAJUZ/piC8sszUkAgv3fLflgzPStIwfWg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1959,12 +1968,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.30.tgz",
-      "integrity": "sha512-6MMHi2Qc1Gkq+4YLXAgbYslE1f9zMGBikKMdmQRHXjkGPot1JY3n5/Qrbg40Uvbi8//wYnydPnyvNhI1DMUW1g==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.32.tgz",
+      "integrity": "sha512-rORQjXsAFeX6TLYJrCG5yoIDj+NKq31Rqwn8Wpn/bkPNy5rTHvOXkW8mLFonItS7QC6M+1JIIcLe+vOCTOYpvg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1974,12 +1984,13 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.30.tgz",
-      "integrity": "sha512-pVZMnFok5qEX4RT59mK2hEVtJX+XFfak+/rjHpyFh7juiT52r177bfFKhnlafm0UOSldhXjj32b+LZIOdswGTg==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.32.tgz",
+      "integrity": "sha512-jHUeDPVHrgFltqoAqDB6g6OStNnFxnc7Aks3p0KE0FbwAvRg6qWKYF5mSTdCTxA3axoSAUwxYdILzXJfUwlHhA==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1989,12 +2000,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.30.tgz",
-      "integrity": "sha512-4KCo8hMZXMjpTzs3HOqOGYYwAXymXIy7PEPAXNEcEOyKqkjiDlECumrWziy+JEF0Oi4ILHGxzgQ3YiMGG2t/Lg==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.32.tgz",
+      "integrity": "sha512-2N0lSoU4GjfLSO50wvKpMQgKd4HdI2UHEhQPPPnlgfBJlOgJxkjpkYBqzk08f1gItBB6xF/n+ykso2hgxuydsA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -9562,10 +9574,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "14.2.30",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.32.tgz",
+      "integrity": "sha512-fg5g0GZ7/nFc09X8wLe6pNSU8cLWbLRG3TZzPJ1BJvi2s9m7eF991se67wliM9kR5yLHRkyGKU49MMx58s3LJg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.30",
+        "@next/env": "14.2.32",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -9580,15 +9594,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.30",
-        "@next/swc-darwin-x64": "14.2.30",
-        "@next/swc-linux-arm64-gnu": "14.2.30",
-        "@next/swc-linux-arm64-musl": "14.2.30",
-        "@next/swc-linux-x64-gnu": "14.2.30",
-        "@next/swc-linux-x64-musl": "14.2.30",
-        "@next/swc-win32-arm64-msvc": "14.2.30",
-        "@next/swc-win32-ia32-msvc": "14.2.30",
-        "@next/swc-win32-x64-msvc": "14.2.30"
+        "@next/swc-darwin-arm64": "14.2.32",
+        "@next/swc-darwin-x64": "14.2.32",
+        "@next/swc-linux-arm64-gnu": "14.2.32",
+        "@next/swc-linux-arm64-musl": "14.2.32",
+        "@next/swc-linux-x64-gnu": "14.2.32",
+        "@next/swc-linux-x64-musl": "14.2.32",
+        "@next/swc-win32-arm64-msvc": "14.2.32",
+        "@next/swc-win32-ia32-msvc": "14.2.32",
+        "@next/swc-win32-x64-msvc": "14.2.32"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -111,7 +111,52 @@
     "impressum": {
     "title": "Legal Information",
     "metaDescription": "Legal information and company details for RAMPA",
-    "content": "Legal information and terms of service for RAMPA will be provided here."
+    "sections": {
+      "companyInfo": {
+        "title": "Company Information",
+        "name": "RAMPA Cash GmbH",
+        "address": "Musterstraße 123",
+        "city": "12345 Berlin",
+        "country": "Germany"
+      },
+      "contact": {
+        "title": "Contact Information",
+        "phone": "Phone:",
+        "email": "Email:",
+        "website": "Website:"
+      },
+      "editoriallyResponsible": {
+        "title": "Editorially Responsible",
+        "name": "RAMPA Cash GmbH",
+        "address": "Musterstraße 123",
+        "city": "12345 Berlin"
+      },
+      "euDispute": {
+        "title": "EU Dispute Resolution",
+        "text": "The European Commission provides a platform for online dispute resolution (ODR):",
+        "link": "https://ec.europa.eu/consumers/odr/",
+        "emailNote": "Our email address can be found above in the impressum."
+      },
+      "consumerDispute": {
+        "title": "Consumer Dispute Resolution",
+        "text": "We are not willing or obliged to participate in dispute resolution proceedings before a consumer arbitration board."
+      },
+      "contentLiability": {
+        "title": "Liability for Content",
+        "paragraph1": "As service providers, we are liable for our own content of these websites according to Sec. 7, Para. 1 German Telemedia Act (TMG). However, pursuant to Secs. 8 to 10 German Telemedia Act (TMG), we as service providers are under no obligation to monitor submitted or stored information or to investigate circumstances pointing to illegal activity.",
+        "paragraph2": "Legal obligations to removing information or to blocking the use of information remain unchallenged. In this case, liability is only possible at the time of knowledge about a specific violation of law. Illegal content will be removed immediately at the time we get knowledge of it."
+      },
+      "linkLiability": {
+        "title": "Liability for Links",
+        "paragraph1": "Our offer includes links to external third party websites. We have no influence on the contents of those websites, therefore we cannot guarantee for those contents. Providers or administrators of linked websites are always responsible for the contents of the linked websites.",
+        "paragraph2": "All linked websites have been checked for possible violations of law at the time of the establishment of the link. Illegal contents were not detected at the time of the linking. A permanent monitoring of the contents of linked websites cannot be imposed without reasonable indications that there has been a violation of law. Illegal links will be removed immediately at the time we get knowledge of it."
+      },
+      "copyright": {
+        "title": "Copyright",
+        "paragraph1": "Contents and compilations published on these websites by the providers are subject to German copyright laws. Reproduction, editing, distribution as well as the use of any kind outside the scope of the copyright law require a written permission of the author or originator.",
+        "paragraph2": "Downloads and copies of these websites are permitted for private use only. The commercial use of our contents without permission of the originator is prohibited."
+      }
+    }
   },
   "cookies": {
     "title": "We use cookies to enhance your experience",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -111,7 +111,52 @@
   "impressum": {
     "title": "Información Legal",
     "metaDescription": "Información legal y detalles de la empresa para RAMPA",
-    "content": "Información legal y términos de servicio para RAMPA se proporcionarán aquí."
+    "sections": {
+      "companyInfo": {
+        "title": "Información de la Empresa",
+        "name": "RAMPA Cash GmbH",
+        "address": "Musterstraße 123",
+        "city": "12345 Berlín",
+        "country": "Alemania"
+      },
+      "contact": {
+        "title": "Información de Contacto",
+        "phone": "Teléfono:",
+        "email": "Email:",
+        "website": "Sitio web:"
+      },
+      "editoriallyResponsible": {
+        "title": "Responsable Editorial",
+        "name": "RAMPA Cash GmbH",
+        "address": "Musterstraße 123",
+        "city": "12345 Berlín"
+      },
+      "euDispute": {
+        "title": "Resolución de Disputas de la UE",
+        "text": "La Comisión Europea proporciona una plataforma para la resolución de disputas en línea (ODR):",
+        "link": "https://ec.europa.eu/consumers/odr/",
+        "emailNote": "Nuestra dirección de correo electrónico se puede encontrar arriba en el aviso legal."
+      },
+      "consumerDispute": {
+        "title": "Resolución de Disputas del Consumidor",
+        "text": "No estamos dispuestos ni obligados a participar en procedimientos de resolución de disputas ante una junta de arbitraje de consumidores."
+      },
+      "contentLiability": {
+        "title": "Responsabilidad por el Contenido",
+        "paragraph1": "Como proveedores de servicios, somos responsables de nuestro propio contenido de estos sitios web según la Sec. 7, Para. 1 de la Ley Alemana de Telemedia (TMG). Sin embargo, de conformidad con las Secs. 8 a 10 de la Ley Alemana de Telemedia (TMG), nosotros como proveedores de servicios no tenemos la obligación de monitorear la información enviada o almacenada o investigar circunstancias que apunten a actividad ilegal.",
+        "paragraph2": "Las obligaciones legales de eliminar información o bloquear el uso de información permanecen sin cambios. En este caso, la responsabilidad solo es posible en el momento del conocimiento sobre una violación específica de la ley. El contenido ilegal será eliminado inmediatamente en el momento en que tengamos conocimiento de ello."
+      },
+      "linkLiability": {
+        "title": "Responsabilidad por Enlaces",
+        "paragraph1": "Nuestra oferta incluye enlaces a sitios web externos de terceros. No tenemos influencia sobre el contenido de esos sitios web, por lo tanto no podemos garantizar ese contenido. Los proveedores o administradores de sitios web enlazados siempre son responsables del contenido de los sitios web enlazados.",
+        "paragraph2": "Todos los sitios web enlazados han sido verificados en busca de posibles violaciones de la ley en el momento del establecimiento del enlace. No se detectaron contenidos ilegales en el momento del enlace. Un monitoreo permanente del contenido de sitios web enlazados no puede imponerse sin indicaciones razonables de que ha habido una violación de la ley. Los enlaces ilegales serán eliminados inmediatamente en el momento en que tengamos conocimiento de ello."
+      },
+      "copyright": {
+        "title": "Derechos de Autor",
+        "paragraph1": "Los contenidos y compilaciones publicados en estos sitios web por los proveedores están sujetos a las leyes alemanas de derechos de autor. La reproducción, edición, distribución así como el uso de cualquier tipo fuera del alcance de la ley de derechos de autor requiere un permiso por escrito del autor u originador.",
+        "paragraph2": "Las descargas y copias de estos sitios web están permitidas solo para uso privado. El uso comercial de nuestros contenidos sin permiso del originador está prohibido."
+      }
+    }
   },
   "cookies": {
     "title": "Usamos cookies para mejorar tu experiencia",


### PR DESCRIPTION
- Add detailed legal information translations for English and Spanish
- Include company info, contact details, EU dispute resolution, and legal disclaimers
- Fix missing translation keys that were showing as raw keys on the page
- Ensure proper localization for both languages